### PR TITLE
Remove README TODO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,5 @@ Static marketing site for Signal & Reason.
 ## Highest-Impact Next Step
 - Add a case studies or services section with clear CTA links.
 
-## Checks
-- Status: failing (GitHub Actions: pages build and deployment).
-- Issue: https://github.com/signalreason/signalreason.com/issues/3
-- TODO: Investigate Pages deployment queue timeouts.
-
 ## Homepage CTA
 The consultation link lives in `index.html` (search for `CTA_URL`).


### PR DESCRIPTION
Agent-Status: ready

## Summary
- Remove README TODO items now tracked as GitHub issues.
- Drop the README section that previously held TODOs.

## Scope
- README cleanup only.

## Dependencies
- None.

## Acceptance Criteria
- [ ] README TODO lines are removed.
- [ ] The section containing README TODOs is removed.

## Test Plan
- [ ] Not applicable (docs-only change).